### PR TITLE
Fix mitaka python version startup 

### DIFF
--- a/monasca_persister/repositories/influxdb/abstract_repository.py
+++ b/monasca_persister/repositories/influxdb/abstract_repository.py
@@ -17,7 +17,7 @@ from influxdb import InfluxDBClient
 from oslo_config import cfg
 import six
 
-from repositories.abstract_repository import AbstractRepository
+from monasca_persister.repositories.abstract_repository import AbstractRepository
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/monasca_persister/repositories/influxdb/alarm_state_history_repository.py
+++ b/monasca_persister/repositories/influxdb/alarm_state_history_repository.py
@@ -18,8 +18,8 @@ import json
 from oslo_log import log
 import pytz
 
-from repositories.influxdb.abstract_repository import AbstractInfluxdbRepository
-from repositories.utils import parse_alarm_state_hist_message
+from monasca_persister.repositories.influxdb.abstract_repository import AbstractInfluxdbRepository
+from monasca_persister.repositories.utils import parse_alarm_state_hist_message
 
 LOG = log.getLogger(__name__)
 

--- a/monasca_persister/repositories/influxdb/metrics_repository.py
+++ b/monasca_persister/repositories/influxdb/metrics_repository.py
@@ -18,8 +18,8 @@ import json
 from oslo_log import log
 import pytz
 
-from repositories.influxdb.abstract_repository import AbstractInfluxdbRepository
-from repositories.utils import parse_measurement_message
+from monasca_persister.repositories.influxdb.abstract_repository import AbstractInfluxdbRepository
+from monasca_persister.repositories.utils import parse_measurement_message
 
 LOG = log.getLogger(__name__)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 oslo.config
-oslo.log
+oslo.log==3.7.0
 oslo.service
 
 six>=1.9.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ license = Apache
 
 [entry_points]
 console_scripts =
-    monasca-persister = monasca_persister.servicerunner:main
+    monasca-persister = monasca_persister.persister:main
 
 [files]
 packages = monasca_persister


### PR DESCRIPTION
This branch makes sure you can start monasca persister right after installation with pip.